### PR TITLE
Add Slow Mode

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -140,6 +140,7 @@ public final class Constants {
 
     // Rotational speed (degrees per second) while manually driving
     public static final AngularVelocity TURN_SPEED = Units.DegreesPerSecond.of(360);
+    public static final double SLOW_MODE_MULTIPLIER = 0.5;
 
     // -- Motor Configurations --
     static {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -134,53 +134,53 @@ public class RobotContainer {
   // --- Driver State Commands ---
   Command MANUAL = Commands.deferredProxy(
       () -> subDriverStateMachine.tryState(DriverStateMachine.DriverState.MANUAL, conDriver.axis_LeftY,
-          conDriver.axis_LeftX, conDriver.axis_RightX));
+          conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
   Command REEF_ROTATION_SNAPPING = Commands.deferredProxy(
       () -> subDriverStateMachine.tryState(DriverStateMachine.DriverState.REEF_ROTATION_SNAPPING,
-          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX));
+          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
   Command CORAL_STATION_ROTATION_SNAPPING = Commands.deferredProxy(
       () -> subDriverStateMachine.tryState(DriverStateMachine.DriverState.CORAL_STATION_ROTATION_SNAPPING,
-          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX));
+          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
   Command REEF_AUTO_DRIVING_LEFT = Commands.deferredProxy(
       () -> subDriverStateMachine.tryState(DriverStateMachine.DriverState.REEF_AUTO_DRIVING_LEFT,
-          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX));
+          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
   Command REEF_AUTO_DRIVING_RIGHT = Commands.deferredProxy(
       () -> subDriverStateMachine.tryState(DriverStateMachine.DriverState.REEF_AUTO_DRIVING_RIGHT,
-          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX));
+          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
   Command CORAL_STATION_AUTO_DRIVING_FAR = Commands.deferredProxy(
       () -> subDriverStateMachine.tryState(DriverStateMachine.DriverState.CORAL_STATION_AUTO_DRIVING_FAR,
-          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX));
+          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
   Command CORAL_STATION_AUTO_DRIVING_CLOSE = Commands.deferredProxy(
       () -> subDriverStateMachine.tryState(DriverStateMachine.DriverState.CORAL_STATION_AUTO_DRIVING_CLOSE,
-          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX));
+          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
   Command PROCESSOR_ROTATION_SNAPPING = Commands.deferredProxy(
       () -> subDriverStateMachine.tryState(DriverStateMachine.DriverState.PROCESSOR_ROTATION_SNAPPING,
-          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX));
+          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
   Command PROCESSOR_AUTO_DRIVING = Commands.deferredProxy(
       () -> subDriverStateMachine.tryState(DriverStateMachine.DriverState.PROCESSOR_AUTO_DRIVING,
-          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX));
+          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
   Command NET_ROTATION_SNAPPING = Commands.deferredProxy(
       () -> subDriverStateMachine.tryState(DriverStateMachine.DriverState.NET_ROTATION_SNAPPING,
-          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX));
+          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
   Command NET_AUTO_DRIVING = Commands.deferredProxy(
       () -> subDriverStateMachine.tryState(DriverStateMachine.DriverState.NET_AUTO_DRIVING,
-          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX));
+          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
   Command ALGAE_ROTATION_SNAPPING = Commands.deferredProxy(
       () -> subDriverStateMachine.tryState(DriverStateMachine.DriverState.ALGAE_ROTATION_SNAPPING,
-          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX));
+          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
   Command ALGAE_AUTO_DRIVING = Commands.deferredProxy(
       () -> subDriverStateMachine.tryState(DriverStateMachine.DriverState.ALGAE_AUTO_DRIVING,
-          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX));
+          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
   Command CAGE_ROTATION_SNAPPING = Commands.deferredProxy(
       () -> subDriverStateMachine.tryState(DriverStateMachine.DriverState.CAGE_ROTATION_SNAPPING,
-          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX));
+          conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
 
   public RobotContainer() {
     conDriver.setLeftDeadband(constControllers.DRIVER_LEFT_STICK_DEADBAND);
 
     subDrivetrain
         .setDefaultCommand(new DriveManual(
-            subDrivetrain, subDriverStateMachine, conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX));
+            subDrivetrain, subDriverStateMachine, conDriver.axis_LeftY, conDriver.axis_LeftX, conDriver.axis_RightX, conDriver.btn_RightBumper.getAsBoolean()));
 
     configDriverBindings();
     configOperatorBindings();

--- a/src/main/java/frc/robot/commands/driver_states/DriveManual.java
+++ b/src/main/java/frc/robot/commands/driver_states/DriveManual.java
@@ -16,9 +16,11 @@ public class DriveManual extends Command {
   DoubleSupplier xAxis, yAxis, rotationAxis;
   boolean isOpenLoop;
   DriverStateMachine subDriverStateMachine;
+  boolean slowMode;
 
   public DriveManual(Drivetrain subDrivetrain, DriverStateMachine subDriverStateMachine, DoubleSupplier xAxis,
-      DoubleSupplier yAxis, DoubleSupplier rotationAxis) {
+      DoubleSupplier yAxis, DoubleSupplier rotationAxis, boolean slowMode) {
+    this.slowMode = slowMode;
     this.subDrivetrain = subDrivetrain;
     this.subDriverStateMachine = subDriverStateMachine;
     this.xAxis = xAxis;
@@ -37,7 +39,7 @@ public class DriveManual extends Command {
 
   @Override
   public void execute() {
-    var velocities = subDrivetrain.calculateVelocitiesFromInput(xAxis, yAxis, rotationAxis);
+    var velocities = subDrivetrain.calculateVelocitiesFromInput(xAxis, yAxis, rotationAxis, slowMode);
 
     subDriverStateMachine.setDriverState(DriverStateMachine.DriverState.MANUAL);
 

--- a/src/main/java/frc/robot/commands/driver_states/PoseDriving.java
+++ b/src/main/java/frc/robot/commands/driver_states/PoseDriving.java
@@ -15,9 +15,11 @@ public class PoseDriving extends Command {
   DriverStateMachine subDriverStateMachine;
   DoubleSupplier xAxis, yAxis, rotationAxis;
   PoseDriveGroup poseGroup;
+  boolean slowMode;
 
   public PoseDriving(Drivetrain subDrivetrain, DriverStateMachine subDriverStateMachine,
-      DoubleSupplier xAxis, DoubleSupplier yAxis, DoubleSupplier rotationAxis, PoseDriveGroup poseGroup) {
+      DoubleSupplier xAxis, DoubleSupplier yAxis, DoubleSupplier rotationAxis, PoseDriveGroup poseGroup, boolean slowMode) {
+    this.slowMode = slowMode;
     this.subDrivetrain = subDrivetrain;
     this.subDriverStateMachine = subDriverStateMachine;
     this.xAxis = xAxis;
@@ -35,7 +37,7 @@ public class PoseDriving extends Command {
   public void execute() {
     Pose2d closestPose = subDrivetrain.getPose().nearest(poseGroup.targetPoseGroup);
 
-    SwerveVelocity velocities = subDrivetrain.calculateVelocitiesFromInput(xAxis, yAxis, rotationAxis);
+    SwerveVelocity velocities = subDrivetrain.calculateVelocitiesFromInput(xAxis, yAxis, rotationAxis, slowMode);
 
     boolean isInAutoDriveZone = subDrivetrain.isInAutoDriveZone(
         poseGroup.minDistanceBeforeDrive,

--- a/src/main/java/frc/robot/subsystems/DriverStateMachine.java
+++ b/src/main/java/frc/robot/subsystems/DriverStateMachine.java
@@ -57,7 +57,7 @@ public class DriverStateMachine extends SubsystemBase {
   }
 
   public Command tryState(DriverState desiredState, DoubleSupplier xAxis,
-      DoubleSupplier yAxis, DoubleSupplier rotationAxis) {
+      DoubleSupplier yAxis, DoubleSupplier rotationAxis, boolean slowMode) {
     switch (desiredState) {
       case MANUAL:
         switch (currentDriverState) {
@@ -75,7 +75,7 @@ public class DriverStateMachine extends SubsystemBase {
           case ALGAE_ROTATION_SNAPPING:
           case ALGAE_AUTO_DRIVING:
           case CAGE_ROTATION_SNAPPING:
-            return new DriveManual(subDrivetrain, subDriverStateMachine, xAxis, yAxis, rotationAxis);
+            return new DriveManual(subDrivetrain, subDriverStateMachine, xAxis, yAxis, rotationAxis, slowMode);
         }
 
         break;
@@ -96,7 +96,7 @@ public class DriverStateMachine extends SubsystemBase {
           case ALGAE_AUTO_DRIVING:
           case CAGE_ROTATION_SNAPPING:
             return new PoseDriving(subDrivetrain, subDriverStateMachine, xAxis, yAxis, rotationAxis,
-                constPoseDrive.CORAL_REEF_LEFT);
+                constPoseDrive.CORAL_REEF_LEFT, slowMode);
         }
         break;
 
@@ -116,7 +116,7 @@ public class DriverStateMachine extends SubsystemBase {
           case ALGAE_AUTO_DRIVING:
           case CAGE_ROTATION_SNAPPING:
             return new PoseDriving(subDrivetrain, subDriverStateMachine, xAxis, yAxis, rotationAxis,
-                constPoseDrive.CORAL_REEF_RIGHT);
+                constPoseDrive.CORAL_REEF_RIGHT, slowMode);
         }
         break;
 
@@ -137,7 +137,7 @@ public class DriverStateMachine extends SubsystemBase {
           case ALGAE_AUTO_DRIVING:
           case CAGE_ROTATION_SNAPPING:
             return new PoseDriving(subDrivetrain, subDriverStateMachine, xAxis, yAxis, rotationAxis,
-                constPoseDrive.CORAL_STATION_FAR);
+                constPoseDrive.CORAL_STATION_FAR, slowMode);
         }
         break;
 
@@ -158,7 +158,7 @@ public class DriverStateMachine extends SubsystemBase {
           case ALGAE_AUTO_DRIVING:
           case CAGE_ROTATION_SNAPPING:
             return new PoseDriving(subDrivetrain, subDriverStateMachine, xAxis, yAxis, rotationAxis,
-                constPoseDrive.CORAL_STATION_CLOSE);
+                constPoseDrive.CORAL_STATION_CLOSE, slowMode);
         }
         break;
 
@@ -179,7 +179,7 @@ public class DriverStateMachine extends SubsystemBase {
           case ALGAE_AUTO_DRIVING:
           case CAGE_ROTATION_SNAPPING:
             return new PoseDriving(subDrivetrain, subDriverStateMachine, xAxis, yAxis, rotationAxis,
-                constPoseDrive.PROCESSOR);
+                constPoseDrive.PROCESSOR, slowMode);
         }
         break;
 
@@ -200,7 +200,7 @@ public class DriverStateMachine extends SubsystemBase {
           case ALGAE_AUTO_DRIVING:
           case CAGE_ROTATION_SNAPPING:
             return new PoseDriving(subDrivetrain, subDriverStateMachine, xAxis, yAxis, rotationAxis,
-                constPoseDrive.PROCESSOR);
+                constPoseDrive.PROCESSOR, slowMode);
         }
         break;
 
@@ -221,7 +221,7 @@ public class DriverStateMachine extends SubsystemBase {
           case ALGAE_AUTO_DRIVING:
           case CAGE_ROTATION_SNAPPING:
             return new PoseDriving(subDrivetrain, subDriverStateMachine, xAxis, yAxis, rotationAxis,
-                constPoseDrive.NET);
+                constPoseDrive.NET, slowMode);
         }
         break;
       case NET_AUTO_DRIVING:
@@ -241,7 +241,7 @@ public class DriverStateMachine extends SubsystemBase {
           case ALGAE_AUTO_DRIVING:
           case CAGE_ROTATION_SNAPPING:
             return new PoseDriving(subDrivetrain, subDriverStateMachine, xAxis, yAxis, rotationAxis,
-                constPoseDrive.NET);
+                constPoseDrive.NET, slowMode);
         }
         break;
       case ALGAE_ROTATION_SNAPPING:
@@ -261,7 +261,7 @@ public class DriverStateMachine extends SubsystemBase {
           case ALGAE_AUTO_DRIVING:
           case CAGE_ROTATION_SNAPPING:
             return new PoseDriving(subDrivetrain, subDriverStateMachine, xAxis, yAxis, rotationAxis,
-                constPoseDrive.ALGAE_REEF);
+                constPoseDrive.ALGAE_REEF, slowMode);
         }
         break;
       case ALGAE_AUTO_DRIVING:
@@ -281,7 +281,7 @@ public class DriverStateMachine extends SubsystemBase {
           case ALGAE_AUTO_DRIVING:
           case CAGE_ROTATION_SNAPPING:
             return new PoseDriving(subDrivetrain, subDriverStateMachine, xAxis, yAxis, rotationAxis,
-                constPoseDrive.ALGAE_REEF);
+                constPoseDrive.ALGAE_REEF, slowMode);
         }
         break;
       case CAGE_ROTATION_SNAPPING:
@@ -301,7 +301,7 @@ public class DriverStateMachine extends SubsystemBase {
           case ALGAE_AUTO_DRIVING:
           case CAGE_ROTATION_SNAPPING:
             return new PoseDriving(subDrivetrain, subDriverStateMachine, xAxis, yAxis, rotationAxis,
-                constPoseDrive.CAGE);
+                constPoseDrive.CAGE, slowMode);
         }
         break;
 

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -110,14 +110,14 @@ public class Drivetrain extends SN_SuperSwerve {
    * @return VelocityResult containing calculated velocities
    */
   public SwerveVelocity calculateVelocitiesFromInput(DoubleSupplier xAxisSupplier, DoubleSupplier yAxisSupplier,
-      DoubleSupplier rotationAxisSupplier) {
+      DoubleSupplier rotationAxisSupplier, boolean slowMode) {
     boolean isRed = isRedAlliance();
     double redAllianceMultiplier = isRed ? -1 : 1;
 
     double xVelocity = xAxisSupplier.getAsDouble() * constDrivetrain.REAL_DRIVE_SPEED.in(Units.MetersPerSecond)
-        * redAllianceMultiplier;
+        * redAllianceMultiplier * (slowMode ? constDrivetrain.SLOW_MODE_MULTIPLIER : 1);
     double yVelocity = -yAxisSupplier.getAsDouble() * constDrivetrain.REAL_DRIVE_SPEED.in(Units.MetersPerSecond)
-        * redAllianceMultiplier;
+        * redAllianceMultiplier * (slowMode ? constDrivetrain.SLOW_MODE_MULTIPLIER : 1);
     double rotationVelocity = rotationAxisSupplier.getAsDouble()
         * constDrivetrain.TURN_SPEED.in(Units.RadiansPerSecond);
 


### PR DESCRIPTION
This pull request introduces a "slow mode" feature to the drivetrain controls, allowing the driver to reduce the robot's speed for more precise maneuvers. The implementation passes a boolean flag—controlled by the right bumper button on the driver's controller—through the command and subsystem layers to scale down the drivetrain velocities.

**Slow mode feature integration:**

* Added a new constant `SLOW_MODE_MULTIPLIER` to `constDrivetrain` for scaling velocities in slow mode.
* Updated all driver state commands in `RobotContainer` to pass the state of the right bumper (`btn_RightBumper.getAsBoolean()`) as the slow mode flag. The default manual drive command also now uses this flag.
* Modified constructors and execution logic in `DriveManual` and `PoseDriving` commands to accept and use the slow mode flag, passing it to velocity calculations. [[1]](diffhunk://#diff-3171d2351dccf5ff71f107daf3eb2ecd997d8bd475199cdbf19bd7412d408af5R19-R23) [[2]](diffhunk://#diff-3171d2351dccf5ff71f107daf3eb2ecd997d8bd475199cdbf19bd7412d408af5L40-R42) [[3]](diffhunk://#diff-05174d0d65063620c7bcedf55bb9954d3490d3acd39f976849e4428382b04258R18-R22) [[4]](diffhunk://#diff-05174d0d65063620c7bcedf55bb9954d3490d3acd39f976849e4428382b04258L38-R40)
* Refactored the `DriverStateMachine.tryState` method to accept and propagate the slow mode flag to all relevant commands. [[1]](diffhunk://#diff-83c82adbb2f46d7ecf1f55369397b872e7fc77ce2ff64b513fe3a7419295f98bL60-R60) [[2]](diffhunk://#diff-83c82adbb2f46d7ecf1f55369397b872e7fc77ce2ff64b513fe3a7419295f98bL78-R78) [[3]](diffhunk://#diff-83c82adbb2f46d7ecf1f55369397b872e7fc77ce2ff64b513fe3a7419295f98bL99-R99) [[4]](diffhunk://#diff-83c82adbb2f46d7ecf1f55369397b872e7fc77ce2ff64b513fe3a7419295f98bL119-R119) [[5]](diffhunk://#diff-83c82adbb2f46d7ecf1f55369397b872e7fc77ce2ff64b513fe3a7419295f98bL140-R140) [[6]](diffhunk://#diff-83c82adbb2f46d7ecf1f55369397b872e7fc77ce2ff64b513fe3a7419295f98bL161-R161) [[7]](diffhunk://#diff-83c82adbb2f46d7ecf1f55369397b872e7fc77ce2ff64b513fe3a7419295f98bL182-R182) [[8]](diffhunk://#diff-83c82adbb2f46d7ecf1f55369397b872e7fc77ce2ff64b513fe3a7419295f98bL203-R203) [[9]](diffhunk://#diff-83c82adbb2f46d7ecf1f55369397b872e7fc77ce2ff64b513fe3a7419295f98bL224-R224) [[10]](diffhunk://#diff-83c82adbb2f46d7ecf1f55369397b872e7fc77ce2ff64b513fe3a7419295f98bL244-R244) [[11]](diffhunk://#diff-83c82adbb2f46d7ecf1f55369397b872e7fc77ce2ff64b513fe3a7419295f98bL264-R264) [[12]](diffhunk://#diff-83c82adbb2f46d7ecf1f55369397b872e7fc77ce2ff64b513fe3a7419295f98bL284-R284) [[13]](diffhunk://#diff-83c82adbb2f46d7ecf1f55369397b872e7fc77ce2ff64b513fe3a7419295f98bL304-R304)
* Updated the `Drivetrain.calculateVelocitiesFromInput` method to scale velocities by `SLOW_MODE_MULTIPLIER` when slow mode is active.

Overall, these changes enable the driver to toggle slow mode for finer control during manual or pose-based driving by holding the right bumper, with the velocity calculations adjusted accordingly throughout the codebase.